### PR TITLE
epoch key selection

### DIFF
--- a/packages/frontend/src/components/MakeOfferModal.tsx
+++ b/packages/frontend/src/components/MakeOfferModal.tsx
@@ -150,11 +150,14 @@ export default observer(
                                             }))
                                         }}
                                     >
-                                        <option value="0">0</option>
-                                        <option value="1">1</option>
-                                        {/* <option value="2">2</option> */}
+                                        <option value="0">1</option>
+                                        <option value="1">2</option>
+                                        <option value="2">3</option>
                                     </select>
-                                    <p>submit offer with epoch key:</p>
+                                    <p>
+                                        Choose one of your anonymous identifiers
+                                        to make this offer
+                                    </p>
                                 </div>
                                 <p className="offer-epoch-key">
                                     {user.epochKey(reqInfo.nonce ?? 0)}

--- a/packages/frontend/src/components/NewListingModal.tsx
+++ b/packages/frontend/src/components/NewListingModal.tsx
@@ -267,12 +267,13 @@ export default observer(({ setShowNewListing }: Props) => {
                                                 }))
                                             }}
                                         >
-                                            <option value="0">0</option>
-                                            <option value="1">1</option>
-                                            {/* <option value="2">2</option> */}
+                                            <option value="0">1</option>
+                                            <option value="1">2</option>
+                                            <option value="2">3</option>
                                         </select>
                                         <p style={{ fontSize: '12px' }}>
-                                            Create listing with epoch key:
+                                            Choose one of your anonymous
+                                            identifiers to post this listing
                                         </p>
                                     </div>
                                     <p


### PR DESCRIPTION
- increased epoch key nonce -- current version of Unirep can now use 3 instead of 2
- changed epoch key selectors from 0 indexed to 1,2,3
- updated selection text to be more descriptive