### PR TITLE
Increase workflow role duration

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -9,6 +9,8 @@ for task in $tasks; do
   aws ecs update-service --cluster trustlist-$env --service $task --force-new-deployment --task-definition $task:$trustlist_revision
 done
 
-aws ecs wait services-stable --cluster trustlist-$env --services $tasks
+for loop in {1..2}; do
+  aws ecs wait services-stable --cluster trustlist-$env --services $tasks && break || continue
+done
 
 exit 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
               uses: aws-actions/configure-aws-credentials@v2
               with:
                   role-to-assume: arn:aws:iam::490752553772:role/trustlist-ecs-deploy-slc
-                  role-duration-seconds: 900
+                  role-duration-seconds: 1500
                   aws-region: eu-central-1
 
             - name: Build and Push images to ECR


### PR DESCRIPTION
Increase workflow role duration and add **aws ecs wait services-stable** into a loop to double timeout.